### PR TITLE
fix cannot run build output when `tests` folder not exists

### DIFF
--- a/.github/actions/get-changes/parse.py
+++ b/.github/actions/get-changes/parse.py
@@ -45,6 +45,9 @@ for pro in problems:
         if file.startswith(prefix):
             flags['tests'][pro] = True
             flags['solutions'][pro] = True
+            if not os.path.exists('p{}/tests'.format(pro)):
+                flags['input'][pro] = True
+                print('Set tests,input/{} to true due to {} (no tests directory)'.format(pro, file))
             print('Set tests,solutions/{} to true due to {}'.format(pro, file))
             break
 


### PR DESCRIPTION
This situation typically occurs when the test generation fails to execute (e.g., due to a generator/solution compilation error), resulting in the absence of the 'tests' folder, and subsequently triggering the build output action.